### PR TITLE
single OXEEnvLogger wrap and more type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ python load_example_oxe.py
 Just add the following lines to your code to wrap your env with the logger. For more detailed example, check `run_gym.py`
 
 ```py
-from oxe_envlogger.env_logger import DmEnvWrapper, make_env_logger
+from oxe_envlogger.env_logger import OXEEnvLogger
 
 env = YOUR_GYM_ENV
-env = DmEnvWrapper(env)
-env = make_env_logger(
+env = OXEEnvLogger(
     env,
     YOUR_DATASET_NAME,
     directory=YOUR_OUTPUT_DIR

--- a/load_example_oxe.py
+++ b/load_example_oxe.py
@@ -62,12 +62,15 @@ if __name__ == "__main__":
     """
 
     is_last = False
+    step_count = 0
     for episode in ds.take(1):  # Take only the first episode for demonstration
         # Unpack the episode
         language_embedding, steps = episode['language_embedding'], episode['steps']
+        assert len(steps) == 1001, "Each episode should have 1001 steps for HalfCheetah env"
 
         # Iterate through steps in the episode
         for step in steps:
+            
             # Accessing step data
             timestamp = step['timestamp'].numpy()
             reward = step['reward'].numpy()

--- a/oxe_envlogger/data_type.py
+++ b/oxe_envlogger/data_type.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import gym
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from dm_env import specs
+
+
+def from_space_to_feature(space_def: gym.Space) -> tfds.features.FeatureConnector:
+    # check if observation space is dict
+    if isinstance(space_def, gym.spaces.Dict):
+        observation_info = tfds.features.FeaturesDict({
+            key: tfds.features.Tensor(shape=space.shape, dtype=space.dtype)
+            for key, space in space_def.spaces.items()
+        })
+    else:
+        observation_info = tfds.features.Tensor(
+            shape=space_def.shape,
+            dtype=space_def.dtype,
+        )
+    return observation_info
+
+
+def from_space_to_spec(space_def: gym.Space, name: str) -> specs:
+    # check if observation space is dict
+    if isinstance(space_def, gym.spaces.Dict):
+        spec = {
+            key: specs.Array(
+                shape=space.shape,
+                dtype=space.dtype,
+                name=key,
+            )
+            for key, space in space_def.spaces.items()
+        }
+    else:
+        spec = specs.Array(
+            shape=space_def.shape,
+            dtype=space_def.dtype,
+            name=name,
+        )
+    return spec

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import numpy as np
+
+import gym
+import dm_env
+from dm_env import specs
+
+from typing import Any, Dict, List, Tuple, Optional, Callable
+from oxe_envlogger.data_type import from_space_to_spec
+
+
+class GymReturn:
+    """
+    Since EnvLogger uses dm_env.Environment interface,
+    we need to convert the return values of dm_env.TimeStep to return values of gym.Env
+    to ensure consistency.
+    """
+
+    def convert_step(val: Any) -> Tuple[np.ndarray, float, bool, bool, Dict]:
+        """
+        This function ensures that the return value of gym.Env.step is consistent
+        :arg val either a dm_env.TimeStep or a tuple of (obs, reward, truncate, terminate, info)
+        :return obs, reward, truncate, terminate, info
+        """
+        if isinstance(val, dm_env.TimeStep):
+            obs = val.observation
+            reward = val.reward
+            truncate = False
+            terminate = val.last()
+            info = {}
+        else:
+            obs, reward, truncate, terminate, info = val
+        return obs, reward, truncate, terminate, info
+
+    def convert_reset(val: Any) -> Tuple[np.ndarray, dict]:
+        """
+        This function ensures that the return value of gym.Env.reset is consistent
+        :arg val either a dm_env.TimeStep or a tuple of (obs, info)
+        :return obs, info
+        """
+        if isinstance(val, dm_env.TimeStep):
+            obs = val.observation
+            info = {}
+        else:
+            obs, info = val
+        return obs, info
+
+
+class DummyDmEnv():
+    """
+    This is a dummy class to use so that the dm_env.Environment interface
+    can still receive the observation_space and action_space. So that the
+    logging can be done in the dm_env.Environment interface.
+
+    https://github.com/google-deepmind/dm_env
+    """
+
+    def __init__(self,
+                 observation_space,
+                 action_space,
+                 step_callback: Callable,
+                 reset_callback: Callable,
+                 ):
+        """
+
+        :param observation_space: gym observation space
+        :param action_space: gym action space
+        :param step_callback: callback function to call gymenv.step
+        :param reset_callback: callback function to call gymenv.reset
+        """
+        self.step_callback = step_callback
+        self.reset_callback = reset_callback
+        self.observation_space = observation_space
+        self.action_space = action_space
+
+    def step(self, action) -> dm_env.TimeStep:
+        val = self.step_callback(action)
+        obs, reward, truncate, terminate, info = val
+        if terminate:
+            ts = dm_env.termination(reward=reward, observation=obs)
+        else:
+            ts = dm_env.transition(reward=reward, observation=obs)
+        return ts
+
+    def reset(self) -> dm_env.TimeStep:
+        obs, _ = self.reset_callback()
+        ts = dm_env.restart(obs)
+        return ts
+
+    def observation_spec(self):
+        return from_space_to_spec(self.observation_space, "observation")
+
+    def action_spec(self):
+        return from_space_to_spec(self.action_space, "action")
+
+    def reward_spec(self):
+        return specs.Array(
+            shape=(),
+            dtype=np.float64,
+            name='reward',
+        )
+
+    def discount_spec(self):
+        return specs.Array(
+            shape=(),
+            dtype=np.float64,
+            name='discount',
+        )
+
+
+class DmEnvWrapper(gym.Wrapper):
+    """
+    This class wraps gym.Env with dm_env.Environment
+    EnvLogger uses dm_env.Environment interface, which requires the use of `spec`
+    and `timestep` as return values of `step` and `reset` methods.
+    https://github.com/google-deepmind/dm_env
+    """
+
+    def __init__(self, env: gym.Env):
+        super().__init__(env)
+
+    def step(self, action) -> dm_env.TimeStep:
+        val = self.env.step(action)
+        obs, reward, truncate, terminate, info = val
+        if terminate:
+            ts = dm_env.termination(reward=reward, observation=obs)
+        else:
+            ts = dm_env.transition(reward=reward, observation=obs)
+        return ts
+
+    def reset(self) -> dm_env.TimeStep:
+        obs, _ = self.env.reset()
+        ts = dm_env.restart(obs)
+        return ts
+
+    def observation_spec(self):
+        return from_space_to_spec(self.env.observation_space, "observation")
+
+    def action_spec(self):
+        return from_space_to_spec(self.env.action_space, "action")
+
+    def reward_spec(self):
+        return specs.Array(
+            shape=(),
+            dtype=np.float64,
+            name='reward',
+        )
+
+    def discount_spec(self):
+        return specs.Array(
+            shape=(),
+            dtype=np.float64,
+            name='discount',
+        )

--- a/oxe_envlogger/env_logger.py
+++ b/oxe_envlogger/env_logger.py
@@ -12,99 +12,8 @@ import tensorflow_datasets as tfds
 import tensorflow as tf
 
 from typing import Any, Dict, List, Tuple, Optional, Callable
-
-
-class DmEnvWrapper(gym.Wrapper):
-    """
-    This class wraps gym.Env with dm_env.Environment
-    EnvLogger uses dm_env.Environment interface, which requires the use of `spec`
-    and `timestep` as return values of `step` and `reset` methods.
-    https://github.com/google-deepmind/dm_env
-    """
-
-    def __init__(self, env: gym.Env):
-        super().__init__(env)
-
-    def step(self, action) -> dm_env.TimeStep:
-        val = self.env.step(action)
-        obs, reward, truncate, terminate, info = val
-        if terminate:
-            ts = dm_env.termination(reward=reward, observation=obs)
-        else:
-            ts = dm_env.transition(reward=reward, observation=obs)
-        return ts
-
-    def reset(self) -> dm_env.TimeStep:
-        obs, _ = self.env.reset()
-        ts = dm_env.restart(obs)
-        return ts
-
-    def observation_spec(self):
-        return specs.Array(
-            shape=self.env.observation_space.shape,
-            dtype=self.env.observation_space.dtype,
-            name='observation',
-        )
-
-    def action_spec(self):
-        return specs.Array(
-            shape=self.env.action_space.shape,
-            dtype=self.env.action_space.dtype,
-            name='action',
-        )
-
-    def reward_spec(self):
-        return specs.Array(
-            shape=(),
-            dtype=np.float64,
-            name='reward',
-        )
-
-    def discount_spec(self):
-        return specs.Array(
-            shape=(),
-            dtype=np.float64,
-            name='discount',
-        )
-
-
-class GymReturn:
-    """
-    Since EnvLogger uses dm_env.Environment interface,
-    we need to convert the return values of dm_env.TimeStep to return values of gym.Env
-    to ensure consistency.
-    """
-    
-    def convert_step(val: Any) -> Tuple[np.ndarray, float, bool, bool, Dict]:
-        """
-        This function ensures that the return value of gym.Env.step is consistent
-        :arg val either a dm_env.TimeStep or a tuple of (obs, reward, truncate, terminate, info)
-        :return obs, reward, truncate, terminate, info
-        """
-        if isinstance(val, dm_env.TimeStep):
-            obs = val.observation
-            reward = val.reward
-            truncate = False
-            terminate = val.last()
-            info = {}
-        else:
-            obs, reward, truncate, terminate, info = val
-        return obs, reward, truncate, terminate, info
-
-
-    def convert_reset(val: Any) -> Tuple[np.ndarray, dict]:
-        """
-        This function ensures that the return value of gym.Env.reset is consistent
-        :arg val either a dm_env.TimeStep or a tuple of (obs, info)
-        :return obs, info
-        """
-        if isinstance(val, dm_env.TimeStep):
-            obs = val.observation
-            info = {}
-        else:
-            obs, info = val
-        return obs, info
-
+from oxe_envlogger.data_type import from_space_to_feature
+from oxe_envlogger.dm_env import GymReturn, DummyDmEnv, DmEnvWrapper
 
 # Define MetadataInfo and MetadataCallback types
 # https://github.com/google-deepmind/envlogger/blob/dc2c6a30be843eeb3fe841737f763ecabcb3a30a/envlogger/environment_logger.py#L45-L48
@@ -113,18 +22,12 @@ MetadataInfo = Dict[str, tfds.features.FeatureConnector]
 MetadataCallback = Callable[[dm_env.TimeStep, Any, dm_env.Environment], Any]
 
 
-def make_env_logger(
-    env: dm_env.Environment,
-    dataset_name: str,
-    directory: str,
-    max_episodes_per_file: int,
-    step_metadata: Optional[Tuple[MetadataInfo, MetadataCallback]] = None,
-    episode_metadata: Optional[Tuple[MetadataInfo, MetadataCallback]] = None,
-    version: str = '0.1.0',
-) -> dm_env.Environment:
+class OXEEnvLogger(gym.Wrapper):
     """
-    Makes an env for a given environment. If custom data needs to be logged,
+    This is the easiest way to wrap gym.Env with EnvLogger. If 
+    custom data needs to be logged,
     add it by passing in `step_metadata` and `episode_metadata`.
+
     args:
         dataset_name: name of the dataset
         env: gym.Env instance
@@ -132,6 +35,115 @@ def make_env_logger(
         max_episodes_per_file: maximum number of episodes to store in a single file
         step_metadata: tuple of (step_metadata_info, step_fn)
         episode_metadata: tuple of (episode_metadata_info, episode_fn)
+    """
+
+    def __init__(
+            self,
+            env: gym.Env,
+            dataset_name: str,
+            directory: str,
+            max_episodes_per_file: int,
+            step_metadata: Optional[Tuple[MetadataInfo,
+                                          MetadataCallback]] = None,
+            episode_metadata: Optional[Tuple[MetadataInfo,
+                                             MetadataCallback]] = None,
+            version: str = '0.1.0',
+    ):
+        super().__init__(env)
+        self.dataset_name = dataset_name
+        self.directory = directory
+        self.max_episodes_per_file = max_episodes_per_file
+        self.step_metadata = step_metadata
+        self.episode_metadata = episode_metadata
+        self.version = version
+
+        def step_callback(action):
+            return self.env.step(action)
+
+        def reset_callback():
+            return self.env.reset()
+
+        self.dm_env = DummyDmEnv(
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            step_callback=step_callback,
+            reset_callback=reset_callback,
+        )
+
+        if step_metadata is None:
+            step_metadata_info, step_fn = None, None
+        else:
+            assert len(
+                step_metadata) == 2, "should be a tuple of (step_metadata_info, step_fn)"
+            step_metadata_info, step_fn = step_metadata
+
+        if episode_metadata is None:
+            episode_metadata_info, episode_fn = None, None
+        else:
+            assert len(
+                episode_metadata) == 2, "should be a tuple of (episode_metadata_info, episode_fn)"
+            episode_metadata_info, episode_fn = episode_metadata
+
+        # https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/rlds/rlds_base.py
+        dataset_config = tfds.rlds.rlds_base.DatasetConfig(
+            name=dataset_name,
+            observation_info=from_space_to_feature(env.observation_space),
+            action_info=from_space_to_feature(env.action_space),
+            reward_info=tf.float64,
+            discount_info=tf.float64,
+            step_metadata_info=step_metadata_info,
+            episode_metadata_info=episode_metadata_info,
+            version=version,
+        )
+
+        writer = tfds_backend_writer.TFDSBackendWriter(
+            data_directory=directory,
+            split_name='train',
+            max_episodes_per_file=max_episodes_per_file,
+            ds_config=dataset_config,
+            version=version,
+        )
+        self.dm_env = envlogger.EnvLogger(self.dm_env,
+                                          step_fn=step_fn,
+                                          episode_fn=episode_fn,
+                                          backend=writer
+                                          )
+
+    def step(self, action) -> Tuple:
+        val = self.dm_env.step(action)
+        return GymReturn.convert_step(val)
+
+    def reset(self) -> Tuple:
+        """Return TupleObservation and Info"""
+        val = self.dm_env.reset()
+        return GymReturn.convert_reset(val)
+
+
+##############################################################################
+
+def make_env_logger(
+    env: DmEnvWrapper,
+    dataset_name: str,
+    directory: str,
+    max_episodes_per_file: int,
+    step_metadata: Optional[Tuple[MetadataInfo, MetadataCallback]] = None,
+    episode_metadata: Optional[Tuple[MetadataInfo, MetadataCallback]] = None,
+    version: str = '0.1.0',
+) -> DmEnvWrapper:
+    """
+    NOTE: the env here is dm_env.Environment, not gym.Env
+    This provides a flexible way to enable logging for dm_env.Environment.
+
+    Usage: 
+        env = DmEnvWrapper(env)
+        env = make_env_logger(
+            env,
+            dataset_name,
+            directory=FLAGS.output_dir,
+            max_episodes_per_file=500,
+            step_metadata=step_metadata,
+            episode_metadata=episode_metadata,
+        )
     """
     # ensure directory exists
     assert os.path.exists(directory), f"{directory} does not exist"
@@ -153,16 +165,8 @@ def make_env_logger(
     # https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/rlds/rlds_base.py
     dataset_config = tfds.rlds.rlds_base.DatasetConfig(
         name=dataset_name,
-        observation_info=tfds.features.Tensor(
-            shape=env.observation_space.shape,
-            dtype=env.observation_space.dtype,
-            encoding=tfds.features.Encoding.ZLIB
-        ),
-        action_info=tfds.features.Tensor(
-            shape=env.action_space.shape,
-            dtype=env.action_space.dtype,
-            encoding=tfds.features.Encoding.ZLIB
-        ),
+        observation_info=from_space_to_feature(env.observation_space),
+        action_info=from_space_to_feature(env.action_space),
         reward_info=tf.float64,
         discount_info=tf.float64,
         step_metadata_info=step_metadata_info,


### PR DESCRIPTION
- Single wrap usage with 

```py
env = YOURENV
env = OXEEnvLogger(env, ........)
```

- Support Dict type spaces: `oxe_envlogger/data_type.py`
  - Will need to manually expand this more to support more static conversion of `gym.Space` to `tfds.features` and `dm-env.specs`