### PR TITLE
type introspection auto_oxe_envlogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,27 @@ python load_example_oxe.py
 
 ## Usage
 
-Just add the following lines to your code to wrap your env with the logger. For more detailed example, check `run_gym.py`
+It is extremely easy to use `OXEEnvLogger`. Just add the following lines to your code to wrap your env with the logger. For more detailed example, check `tests/log_env.py` or `run_gym.py`.
+
+**1. AutoOXEEnvLogger** (with type introspection)
+
+```py
+from oxe_envlogger.envlogger import AutoOXEEnvLogger
+
+env = YOUR_GYM_ENV
+env = AutoOXEEnvLogger(
+    env,
+    YOUR_DATASET_NAME,
+)
+```
+
+The above code will automatically obtain the observation and action space from the env, and also support custom metadata. The optimal shard size is 
+automatically calculated based on the first episode. Use `set_step_metadata()` and `set_episode_metadata()` to set the metadata for each step and episode respectively. Log is saved in `logs/YOUR_DATASET_NAME` by default.
+
+**2. OXEEnvLogger** (without type introspection)
+
+For more fine-grained type casting of the data, use `OXEEnvLogger`. This requires
+the correct type cast of `self.action_space` and `self.observation_space` in the gym.env class.
 
 ```py
 from oxe_envlogger.envlogger import OXEEnvLogger
@@ -64,8 +84,12 @@ env = OXEEnvLogger(
     YOUR_DATASET_NAME,
     directory=YOUR_OUTPUT_DIR
     max_episodes_per_file=500,
+    # step_metadata_info=YOUR_METADATA, # optional
+    # episode_metadata_info=YOUR_METADATA, # optional
 )
 ```
+
+**3. RLDSLogger**
 
 Or, you can use the RLDSLogger to log the data manually. For more detailed example, check `tests/log_rlds.py`
 

--- a/oxe_envlogger/data_type.py
+++ b/oxe_envlogger/data_type.py
@@ -28,8 +28,30 @@ def get_gym_space(data_sample: Any) -> gym.spaces.Space:
         # Recursively convert each item in the dictionary
         return gym.spaces.Dict({key: get_gym_space(value)
                                 for key, value in data_sample.items()})
+    elif isinstance(data_sample, (int, float, str)):
+        return gym.spaces.Discrete(1)
     else:
         raise TypeError("Unsupported data type for Gym spaces conversion.")
+
+
+def get_tfds_feature(data_sample: Any) -> tfds.features.FeatureConnector:
+    """
+    Get the data type as tfds feature of a provided data sample.
+    Similar to the get_gym_space function above
+    """
+    if isinstance(data_sample, (np.ndarray, list, tuple)):
+        data_sample = np.array(data_sample)
+        return tfds.features.Tensor(shape=data_sample.shape,
+                                    dtype=data_sample.dtype)
+    elif isinstance(data_sample, dict):
+        return tfds.features.FeaturesDict({key: get_tfds_feature(value)
+                                           for key, value in data_sample.items()})
+    elif isinstance(data_sample, (int, np.int32, np.int64)):
+        return tfds.features.Tensor(shape=(), dtype=tf.int64)
+    elif isinstance(data_sample, (float, np.float32, np.float64)):
+        return tfds.features.Tensor(shape=(), dtype=tf.float64)
+    else:
+        raise TypeError(f"Unsupported data type for tfds features conversion, {type(data_sample)}")
 
 
 def from_space_to_feature(space_def: gym.Space,
@@ -111,6 +133,8 @@ def enforce_type_consistency(space: gym.Space, data: Any) -> Any:
         for key, space in space.spaces.items():
             data[key] = enforce_type_consistency(space, data[key])
     else:
+        if not isinstance(data, np.ndarray): # might want to not convert to np array
+            data = np.array(data, dtype=space.dtype)
         assert space.shape == data.shape, f" mismatch shape"
         data = data.astype(space.dtype)
     return data

--- a/oxe_envlogger/envlogger.py
+++ b/oxe_envlogger/envlogger.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+from oxe_envlogger.data_type import get_tfds_feature
+import sys
 import os
 import numpy as np
 
 import gym
 import envlogger
-import dm_env
 from envlogger.backends import tfds_backend_writer
 import tensorflow_datasets as tfds
 import tensorflow as tf
@@ -13,11 +14,52 @@ import tensorflow as tf
 from typing import Any, Dict, List, Tuple, Optional, Callable
 from oxe_envlogger.data_type import from_space_to_feature, populate_docs, enforce_type_consistency
 from oxe_envlogger.dm_env import GymReturn, DummyDmEnv, DmEnvWrapper
+from abc import ABC, abstractmethod
+
+
+def print_yellow(x): return print("\033[93m" + x + "\033[0m")
+
+
+class EnvLoggerBase(ABC):
+    @abstractmethod
+    def step(self, action, **kwargs) -> Tuple:
+        """Standard gym step()
+        :return Tuple:     obs, reward, truncate, terminate, info
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset(self, **kwargs) -> Tuple:
+        """Standard gym reset()
+        :return Tuple:   obs, info
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_step_metadata(self, metadata: Dict[str, Any]):
+        """Set the step metadata to log, call this before step() and reset()
+        :param metadata: dict of metadata to log
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_episode_metadata(self, metadata: Dict[str, Any]):
+        """Set the episode metadata to log, call this before reset()
+        :param metadata: dict of metadata to log
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self):
+        """Close the logger, flush the data to disk
+        """
+        raise NotImplementedError
+
+
+##############################################################################
 
 # Define MetadataInfo and MetadataCallback types
 # https://github.com/google-deepmind/envlogger/blob/dc2c6a30be843eeb3fe841737f763ecabcb3a30a/envlogger/environment_logger.py#L45-L48
-
-
 """
 example of MetadataInfo:
     step_metadata_info = {'timestamp': tfds.features.Tensor(
@@ -27,7 +69,7 @@ MetadataInfo = Dict[str, tfds.features.FeatureConnector]
 DocField = Dict[str, str]
 
 
-class OXEEnvLogger(gym.Wrapper):
+class OXEEnvLogger(gym.Wrapper, EnvLoggerBase):
     """
     This is the easiest way to wrap gym.Env with EnvLogger. If 
     custom data needs to be logged,
@@ -63,40 +105,24 @@ class OXEEnvLogger(gym.Wrapper):
         self.version = version
         self.step_metadata_info = step_metadata_info
         self.episode_metadata_info = episode_metadata_info
-        # this is a hack to pass in kwargs to the step and reset function
-        self.step_kwargs = {}
-        self.reset_kwargs = {}
 
         # check if directory exists else create it
         if not os.path.exists(directory):
             os.makedirs(directory)
             print(f"Create new directory: {directory}")
 
-        def step_callback(action):
-            action = enforce_type_consistency(env.action_space, action)
-            return self.env.step(action, **self.step_kwargs)
-
-        def reset_callback():
-            return self.env.reset(**self.reset_kwargs)
-
-        self.dm_env = DummyDmEnv(
-            observation_space=env.observation_space,
-            action_space=env.action_space,
-            step_callback=step_callback,
-            reset_callback=reset_callback,
-        )
-
-        step_fn = None
+        # Metadata step and episode functions callback
+        step_metadata_fn = None
         self.step_metadata_elements = {}
         if step_metadata_info is not None:
-            def step_fn(timestep, action, env):
+            def step_metadata_fn(timestep, action, env):
                 assert self.step_metadata_elements, "step metadata not set"
                 return self.step_metadata_elements
 
+        episode_metadata_fn = None
         self.episode_metadata_elements = {}
-        episode_fn = None
         if episode_metadata_info is not None:
-            def episode_fn(timestep, action, env):
+            def episode_metadata_fn(timestep, action, env):
                 assert self.episode_metadata_elements, "episode metadata not set"
                 return self.episode_metadata_elements
 
@@ -124,57 +150,216 @@ class OXEEnvLogger(gym.Wrapper):
             version=version,
             store_ds_metadata=True,
         )
-        self.dm_env = envlogger.EnvLogger(self.dm_env,
-                                          step_fn=step_fn,
-                                          episode_fn=episode_fn,
+
+        dm_env = DummyDmEnv(env)
+        self.dm_env = envlogger.EnvLogger(dm_env,
+                                          step_fn=step_metadata_fn,
+                                          episode_fn=episode_metadata_fn,
                                           backend=writer
                                           )
         print("Done wrapping environment with EnvironmentLogger.")
 
     def step(self, action, **kwargs) -> Tuple:
-        """
-        Return Tuple:
-            obs, reward, truncate, terminate, info
-        """
-        self.step_kwargs = kwargs
+        """Refer to abstract method in EnvLoggerBase"""
+        self.dm_env.step_kwargs = kwargs  # experimental
         val = self.dm_env.step(action)
-        self.step_kwargs = {}
+        self.dm_env.step_kwargs = {}
         return GymReturn.convert_step(val)
 
     def reset(self, **kwargs) -> Tuple:
-        """
-        Return Tuple:
-            Observation and Info
-        """
-        self.reset_kwargs = kwargs
+        """Refer to abstract method in EnvLoggerBase"""
+        self.dm_env.reset_kwargs = kwargs  # experimental
         val = self.dm_env.reset()
-        self.reset_kwargs = {}
+        self.dm_env.reset_kwargs = {}
         return GymReturn.convert_reset(val)
 
     def set_step_metadata(self, metadata: Dict[str, Any]):
-        """
-        Log step metadata, provide a dict of metadata to log
-        NOTE: make sure all defined keys are present
-            :arg metadata dict of metadata to log
-        """
+        """Refer to abstract method in EnvLoggerBase"""
         assert len(metadata) == len(
             self.step_metadata_info), "metadata definition mismatch"
         assert set(metadata.keys()) == set(self.step_metadata_info.keys())
         self.step_metadata_elements = metadata
 
     def set_episode_metadata(self, metadata: Dict[str, Any]):
-        """
-        Log episode metadata, provide a dict of metadata to log
-        NOTE: make sure all the defined keys are present
-            :arg metadata dict of metadata to log
-        """
+        """Refer to abstract method in EnvLoggerBase"""
         assert len(metadata) == len(
             self.episode_metadata_info), "metadata definition mismatch"
         assert set(metadata.keys()) == set(self.episode_metadata_info.keys())
         self.episode_metadata_elements = metadata
 
+    def close(self):
+        self.dm_env.close()
+
 
 ##############################################################################
+
+
+class AutoOXEEnvLogger(gym.Wrapper, EnvLoggerBase):
+    """
+    This provides the most flexible way to wrap gym.Env with EnvLogger. With
+    type introspection, AutoOXEEnvLogger automatically obtains the specs of 
+    the observation, action, metadata specs from the gym.Env instance.
+    The optimal size of shards is automatically calculated based on the 
+    first episode.
+    NOTE: the first episode is discarded to initialize the logger.
+    """
+    def __init__(
+            self,
+            env: gym.Env,
+            dataset_name: str,
+            directory: str = None,
+            optimal_shard_size: int = 100,
+    ):
+        """
+        args:
+            dataset_name: name of the dataset
+            env: gym.Env instance
+            directory: directory to store the trajectories
+            optimal_shard_size: optimal size of each tfrecord file in MB
+        """
+        super().__init__(env)
+        self.dataset_name = dataset_name
+        self.directory = directory
+
+        # check if directory is specified, else create it
+        if directory is None:
+            directory = os.getcwd() + f"/logs/{dataset_name}"
+
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+            print(f"Create new directory: {directory}")
+        self.directory = directory
+
+        self._internal_episode_count = 0
+        self._temp_init_step_data = []
+        self.default_version = '0.1.0'
+        self.optimal_shard_size = optimal_shard_size
+        self.step_metadata_elements = {}
+        self.episode_metadata_elements = {}
+
+    def __init_logger(self):
+        """
+        This function is called when the first episode is observed.
+        It creates the metadata specs and the tfrecord writer.
+        """
+        print_yellow("Initializing logger...")
+        # convert to mb
+        epi_size = (
+            sys.getsizeof(self._temp_init_step_data) +
+            sys.getsizeof(self.episode_metadata_elements)
+        ) / 1024 / 1024
+        max_episodes_per_file = int(self.optimal_shard_size / epi_size)
+        print_yellow(f"Size of first episode: {epi_size} MB, "
+                     f"with shard size: {max_episodes_per_file} episodes")
+
+        # Take last metadata for episode and step
+        self.episode_metadata_elements = self.episode_metadata_elements.copy()
+        self.step_metadata_elements = self.step_metadata_elements.copy()
+
+        assert len(self._temp_init_step_data) > 0, "no step data!"
+
+        # NOTE: we will only take the first element of the list
+        first_step_data = self._temp_init_step_data[0]
+        observation_info = get_tfds_feature(first_step_data['obs'])
+        action_info = get_tfds_feature(first_step_data['action'])
+        step_metadata_info = first_step_data['metadata']
+        episode_metadata_info = self.episode_metadata_elements
+        for key, value in step_metadata_info.items():
+            step_metadata_info[key] = get_tfds_feature(value)
+        for key, value in episode_metadata_info.items():
+            episode_metadata_info[key] = get_tfds_feature(value)
+
+        # TODO: check consistency within the step data, else throw error
+
+        # https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/rlds/rlds_base.py
+        self.dataset_config = tfds.rlds.rlds_base.DatasetConfig(
+            name=self.dataset_name,
+            observation_info=observation_info,
+            action_info=action_info,
+            reward_info=tf.float64,
+            discount_info=tf.float64,
+            step_metadata_info=step_metadata_info,
+            episode_metadata_info=episode_metadata_info,
+            version=self.default_version,
+        )
+
+        writer = tfds_backend_writer.TFDSBackendWriter(
+            data_directory=self.directory,
+            split_name='train',
+            max_episodes_per_file=max_episodes_per_file,
+            ds_config=self.dataset_config,
+            version=self.default_version,
+            store_ds_metadata=True,
+        )
+
+        # metadata callback handler
+        step_metadata_fn = None
+        episode_metadata_fn = None
+
+        if self.step_metadata_elements:
+            def step_metadata_fn(timestep, action, env):
+                return self.step_metadata_elements
+        if self.episode_metadata_elements:
+            def episode_metadata_fn(timestep, action, env):
+                return self.episode_metadata_elements
+
+        self.dm_env = DummyDmEnv(self.env)
+        self.dm_env = envlogger.EnvLogger(self.dm_env,
+                                          step_fn=step_metadata_fn,
+                                          episode_fn=episode_metadata_fn,
+                                          backend=writer
+                                          )
+
+        # TODO maybe dont discard the first episode and manually log it
+        self._temp_init_step_data = None  # clear temp memory
+        print_yellow("Done initializing logger.")
+
+    def reset(self, **kwargs):
+        """Refer to abstract method in EnvLoggerBase"""
+        if self._internal_episode_count < 2:  # when init
+            if self._internal_episode_count == 0:
+                print("collecting first episode to initialize logger...")
+                self._internal_episode_count += 1
+                return self.env.reset(**kwargs)
+            elif self._internal_episode_count == 1:
+                self.__init_logger()
+                self._internal_episode_count += 1
+                # NOTE: would need to log this 2nd reset
+        val = self.dm_env.reset(**kwargs)
+        return GymReturn.convert_reset(val)
+
+    def step(self, action, **kwargs):
+        """Refer to abstract method in EnvLoggerBase"""
+        if self._internal_episode_count < 2:  # when init
+            ret_tuple = self.env.step(action, **kwargs)
+            self._temp_init_step_data.append(
+                dict(
+                    obs=ret_tuple[0],
+                    action=action,
+                    metadata=self.step_metadata_elements,
+                    reward=ret_tuple[1],
+                    terminate=ret_tuple[2],
+                    truncate=ret_tuple[3],
+                )
+            )
+            return ret_tuple
+        else:
+            val = self.dm_env.step(action, **kwargs)
+            return GymReturn.convert_step(val)
+
+    def set_step_metadata(self, metadata: Dict[str, Any]):
+        """Refer to abstract method in EnvLoggerBase"""
+        self.step_metadata_elements = metadata
+
+    def set_episode_metadata(self, metadata: Dict[str, Any]):
+        """Refer to abstract method in EnvLoggerBase"""
+        self.episode_metadata_elements.update(metadata)
+
+    def close(self):
+        self.dm_env.close()
+
+##############################################################################
+
 
 """
 example of MetadataCallback:

--- a/run_gym.py
+++ b/run_gym.py
@@ -16,7 +16,7 @@ flags.DEFINE_integer('num_episodes', 10, 'Number of episodes to log.')
 flags.DEFINE_string('output_dir', 'datasets/',
                     'Path in a filesystem to record trajectories.')
 flags.DEFINE_string('env_name', 'CartPole-v1', 'Name of the environment.')
-flags.DEFINE_boolean('enable_envlogger', False, 'Enable envlogger.')
+flags.DEFINE_boolean('enable_envlogger', True, 'Enable envlogger.')
 
 
 ##############################################################################

--- a/tests/log_env.py
+++ b/tests/log_env.py
@@ -1,0 +1,98 @@
+import tensorflow_datasets as tfds
+from oxe_envlogger.envlogger import OXEEnvLogger, AutoOXEEnvLogger
+
+import numpy as np
+import gym
+
+import tensorflow as tf
+import time
+
+
+def main(auto_logger=False):
+    print("##########################################")
+    print("## Testing with auto_logger: ", auto_logger)
+
+    env = gym.make("CartPole-v1")
+    
+    # generate a random name for the dataset
+    random_name_suffix = np.random.randint(1000)
+    ds_name = f"test_env_{random_name_suffix}"
+
+    if auto_logger:
+        env = AutoOXEEnvLogger(
+            env=env,
+            dataset_name=ds_name,
+            directory="logs",
+        )
+    else:
+        step_metadata_info = {'timestamp': tfds.features.Tensor(shape=(),
+                                                                dtype=tf.float32,
+                                                                doc="Timestamp for the step.")}
+        episode_metadata_info = {'language_embedding': tfds.features.Tensor(
+            shape=(5,),
+            dtype=tf.float32,
+            doc="Language embedding for the episode.")}
+
+        env = OXEEnvLogger(
+            env=env,
+            dataset_name=ds_name,
+            directory="logs",
+            max_episodes_per_file=10,
+            step_metadata_info=step_metadata_info,
+            episode_metadata_info=episode_metadata_info,
+        )
+
+    print("Done setting up logger")
+
+    for i in range(3):
+        env.set_episode_metadata({"language_embedding": np.random.rand(5).astype(np.float32)})
+        env.set_step_metadata({"timestamp": time.time()})
+        print("episode", i)
+        env.reset()
+        for i in range(10):
+            env.set_step_metadata({"timestamp": time.time()})
+            env.step(env.action_space.sample())
+
+    env.close()  # explicitly close the env logger to flush the data to disk
+
+    print("Done logging")
+
+    ##############################################################################
+    # Test Cases
+    ##############################################################################
+
+    ds_builder = tfds.builder_from_directory("logs")
+    dataset = ds_builder.as_dataset(split='all')
+
+    assert ds_builder.info.name == ds_name, f"dataset name should be {ds_name}"
+
+    num_of_episodes = 2 if auto_logger else 3
+
+    # print len of dataset
+    print("size of dataset", len(list(dataset)))
+    assert len(list(dataset)) == num_of_episodes, f"There should be {num_of_episodes} episodes in the dataset"
+
+    for episode in dataset.take(num_of_episodes):  # Take only the first episode for demonstration
+        steps = episode['steps']
+
+        num_steps = len(list(steps))
+        assert num_steps == 11, "epi should have 1 + 10 steps"
+        assert "language_embedding" in episode.keys()
+
+        # Iterate through steps in the episode
+        for i, step in enumerate(steps):
+            if i == 0:
+                assert step['is_first'].numpy() == True, "first step is is_first=True"
+            else:
+                assert step['is_first'].numpy() == False, "non-first step is is_first=False"
+
+            assert "timestamp" in step.keys(), "step should have timestamp metadata"
+
+
+
+if __name__ == "__main__":
+    print("Testing OXEEnvLogger")
+    main(auto_logger=False)
+    main(auto_logger=True)
+    print("Done All")
+    

--- a/tests/log_rlds.py
+++ b/tests/log_rlds.py
@@ -15,7 +15,7 @@ def main(_):
     logger = RLDSLogger(
         observation_space=get_gym_space(obs_sample),
         action_space=get_gym_space(action_sample),
-        dataset_name="test",
+        dataset_name="test_rlds",
         directory="logs",
         max_episodes_per_file=1,
     )


### PR DESCRIPTION
Introduces `AutoOXEEnvLogger` for auto type introspection with the first episode. This meant to be the easiest way of using the oxe_envlogger without the pain of configuring the specs of each type.

The optimal number of episode per shard/file is calculated from the size usage in the first episode.

example:
```py
from oxe_envlogger.envlogger import AutoOXEEnvLogger

env = YOUR_GYM_ENV
env = AutoOXEEnvLogger(
    env,
    YOUR_DATASET_NAME,
)
```

For usage, please refer to the test script [tests/log_env.py](https://github.com/rail-berkeley/oxe_envlogger/blob/type-introspection-logger/tests/log_env.py)

Note:
- previous PR introduced https://github.com/rail-berkeley/oxe_envlogger/pull/6, for easy logging without a gym env