### PR TITLE
script to merge rlds datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,9 @@ Notes: type casting is very important in the env logger. For example, the define
 Script to merge recorded rlds datasets
 
 ```bash
-python3 merge_datasets.py --log_dirs all_logs --output_dir output --shard_size 15
+# --log_dirs: directory that contains of nested directories of rlds logs
+# --output_dir: directory to store the merged rlds logs
+# --shard_size: number of episodes per file
+# --overwrite: overwrite the output directory
+python3 merge_datasets.py --overwrite --log_dirs all_logs --output_dir output --shard_size 15
 ```

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ logger.close() # this is important to flush the current data to disk
 ```
 
 Notes: type casting is very important in the env logger. For example, the defined `action_space` and `observation_space` in the env should be provided/returned as what they are defined. Otherwise, the logger will raise an error. Also, take note of specific types like `float32`/`float64`, `int32`/`int64` etc.
+
+## Utilities
+
+Script to merge recorded rlds datasets
+
+```bash
+python3 merge_datasets.py --log_dirs all_logs --output_dir output --shard_size 15
+```

--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 import copy
-from typing import Tuple, Dict, List, Any, Optional
 from oxe_envlogger.utils import \
     print_yellow, find_datasets, get_datasets, merge_datasets, save_rlds_dataset
-
 
 
 if __name__ == "__main__":
@@ -12,6 +12,7 @@ if __name__ == "__main__":
     parser.add_argument("--log_dirs", type=str, nargs='+')
     parser.add_argument("--output_dir", type=str, default='merged_logs')
     parser.add_argument("--overwrite", action='store_true')
+    parser.add_argument("--shard_size", type=int, default=1500, help="Max episodes per shard")
     args = parser.parse_args()
 
     dataset_dirs = find_datasets(args.log_dirs)
@@ -35,7 +36,7 @@ if __name__ == "__main__":
         os.makedirs(args.output_dir)
 
     save_rlds_dataset(merged_dataset, dataset_info,
-                      max_episodes_per_shard=1000,
+                      max_episodes_per_shard=args.shard_size,
                       overwrite=args.overwrite
                       )
     print(f"Saved merged dataset to {args.output_dir}")

--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -4,7 +4,10 @@ import os
 import argparse
 import copy
 from oxe_envlogger.utils import \
-    print_yellow, find_datasets, get_datasets, merge_datasets, save_rlds_dataset
+    find_datasets, get_datasets, merge_datasets, save_rlds_dataset
+
+
+def print_yellow(x): return print("\033[93m {}\033[00m" .format(x))
 
 
 if __name__ == "__main__":
@@ -18,25 +21,30 @@ if __name__ == "__main__":
     dataset_dirs = find_datasets(args.log_dirs)
     datasets, dataset_infos = get_datasets(dataset_dirs)
     merged_dataset = merge_datasets(datasets)
-    print_yellow(f"Merging {len(datasets)} datasets with {len(merged_dataset)} episodes.")
+    print_yellow(f"Merging {len(datasets)} datasets with \
+                   total {len(merged_dataset)} episodes.")
 
     def update_data_dir(target_dir, dataset_info):
         # Bug in update_data_dir() method, need to update the identity object as well
-        # https://github.com/tensorflow/datasets/blob/v4.9.3/tensorflow_datasets/core/dataset_info.py#L528
+        # https://github.com/tensorflow/datasets/pull/5297
         dataset_info.update_data_dir(target_dir)
         dataset_info._identity.data_dir = target_dir
 
     dataset_info = copy.deepcopy(dataset_infos[0])
     update_data_dir(args.output_dir, dataset_info)
-    print_yellow(dataset_info)
+    print(dataset_info)
     print_yellow(f"Saving merged dataset to [{args.output_dir}]")
     assert dataset_info.data_dir == args.output_dir
 
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
 
-    save_rlds_dataset(merged_dataset, dataset_info,
-                      max_episodes_per_shard=args.shard_size,
-                      overwrite=args.overwrite
-                      )
-    print(f"Saved merged dataset to {args.output_dir}")
+    print_yellow(f"Writing episodes to disk... with {len(merged_dataset)} episodes.")
+    save_rlds_dataset(
+        dataset=merged_dataset,
+        dataset_info=dataset_info,
+        max_episodes_per_shard=args.shard_size,
+        overwrite=args.overwrite
+    )
+    print("new ", dataset_info)
+    print_yellow(f"Saved merged dataset to {args.output_dir}")

--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+import copy
+from typing import Tuple, Dict, List, Any, Optional
+from oxe_envlogger.utils import \
+    print_yellow, find_datasets, get_datasets, merge_datasets, save_rlds_dataset
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log_dirs", type=str, nargs='+')
+    parser.add_argument("--output_dir", type=str, default='merged_logs')
+    parser.add_argument("--overwrite", action='store_true')
+    args = parser.parse_args()
+
+    dataset_dirs = find_datasets(args.log_dirs)
+    datasets, dataset_infos = get_datasets(dataset_dirs)
+    merged_dataset = merge_datasets(datasets)
+    print_yellow(f"Merging {len(datasets)} datasets with {len(merged_dataset)} episodes.")
+
+    def update_data_dir(target_dir, dataset_info):
+        # Bug in update_data_dir() method, need to update the identity object as well
+        # https://github.com/tensorflow/datasets/blob/v4.9.3/tensorflow_datasets/core/dataset_info.py#L528
+        dataset_info.update_data_dir(target_dir)
+        dataset_info._identity.data_dir = target_dir
+
+    dataset_info = copy.deepcopy(dataset_infos[0])
+    update_data_dir(args.output_dir, dataset_info)
+    print_yellow(dataset_info)
+    print_yellow(f"Saving merged dataset to [{args.output_dir}]")
+    assert dataset_info.data_dir == args.output_dir
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+
+    save_rlds_dataset(merged_dataset, dataset_info,
+                      max_episodes_per_shard=1000,
+                      overwrite=args.overwrite
+                      )
+    print(f"Saved merged dataset to {args.output_dir}")

--- a/oxe_envlogger/utils.py
+++ b/oxe_envlogger/utils.py
@@ -1,0 +1,105 @@
+import tensorflow as tf
+import tensorflow_datasets as tfds
+import os
+from typing import Tuple, Dict, List, Any, Optional
+from tensorflow_datasets.core import SequentialWriter
+
+
+def print_yellow(x): return print("\033[93m {}\033[00m" .format(x))
+
+
+def find_datasets(log_dirs=['logs']) -> List[str]:
+    """
+    Finds dataset directories within specified log directories.
+
+    Args:
+        log_dirs (list of str): Directories to search for datasets.
+
+    Returns:
+        list of str: A list of dataset directories.
+    """
+    datasets_dirs = []
+    for log_dir in log_dirs:
+        if os.path.isdir(log_dir):
+            for dir in os.listdir(log_dir):
+                dir_path = os.path.join(log_dir, dir)
+                if os.path.isdir(dir_path):
+                    datasets_dirs.append(dir_path)
+    return datasets_dirs
+
+
+def get_datasets(
+    dataset_dirs: List[str],
+) -> Tuple[List[tf.data.Dataset], List[tfds.core.DatasetInfo]]:
+    """
+    Load datasets from given directories.
+    args:
+        dataset_dirs: list of dataset directories
+    returns:
+        datasets: list of datasets
+        dataset_infos: list of dataset info
+    """
+    datasets = []
+    dataset_infos = []
+    for dataset_dir in dataset_dirs:
+        temp_d = tfds.builder_from_directory(dataset_dir)
+        dataset = temp_d.as_dataset(split='all')
+        datasets.append(dataset)
+        dataset_infos.append(temp_d.info)
+    return datasets, dataset_infos
+
+
+def merge_datasets(datasets: List[tf.data.Dataset]) -> tf.data.Dataset:
+    """
+    Merges datasets and returns the merged dataset.
+
+    Args:
+        datasets (list of tf.data.Dataset): A list of datasets to merge.
+
+    Returns:
+        tf.data.Dataset: A merged dataset.
+    """
+    # Assuming the datasets are compatible, we can concatenate them.
+    merged_dataset = datasets[0]
+    for dataset in datasets[1:]:
+        merged_dataset = merged_dataset.concatenate(dataset)
+
+        dataset.save(
+            "test"
+        )
+    return merged_dataset
+
+
+def save_rlds_dataset(
+    dataset: tf.data.Dataset,
+    dataset_info: tfds.core.DatasetInfo,
+    max_episodes_per_shard: int = 1000,
+    overwrite: bool = False,
+):
+    # Convert observation and action spaces to TFDS features
+    writer = SequentialWriter(
+        dataset_info, max_episodes_per_shard, overwrite=overwrite
+    )
+    writer.initialize_splits(["train"], fail_if_exists=False)
+
+    def recursive_dict_to_numpy(d):
+        for k, v in d.items():
+            if isinstance(v, dict):
+                recursive_dict_to_numpy(v)
+            else:
+                d[k] = v.numpy()
+        return d
+
+    # Write episodes to disk
+    print_yellow(f"Writing episodes to disk... with {len(dataset)} episodes.")
+    for episode in dataset:
+        for step in episode["steps"]:
+            # convert each values in the step dict to numpy array
+            # TODO: THIS IS A HACK!!! since the sequence writer uses
+            # https://github.com/tensorflow/datasets/blob/ab25353173afa5fa01d03759a5e482c82d4fd889/tensorflow_datasets/core/features/tensor_feature.py#L149
+            # API, which will throw an error if the input is not a numpy array
+            step = recursive_dict_to_numpy(step)
+            writer.add_examples(
+                {"train": [{"steps": [step]}]}
+            )
+    writer.close_all()

--- a/oxe_envlogger/utils.py
+++ b/oxe_envlogger/utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import tensorflow as tf
 import tensorflow_datasets as tfds
 import os
@@ -63,10 +65,6 @@ def merge_datasets(datasets: List[tf.data.Dataset]) -> tf.data.Dataset:
     merged_dataset = datasets[0]
     for dataset in datasets[1:]:
         merged_dataset = merged_dataset.concatenate(dataset)
-
-        dataset.save(
-            "test"
-        )
     return merged_dataset
 
 


### PR DESCRIPTION
# To test

say all datasets are located in `all_logs/`, just run the following command to merge all datasets and output to `merged_dir`

```bash
python3 merge_datasets.py --log_dirs all_logs --output_dir merged_dir
```

