### PR TITLE
resolve type casting for octo finetuning logging

### DIFF
--- a/oxe_envlogger/data_type.py
+++ b/oxe_envlogger/data_type.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import numpy as np
-# try:
-#     import gymnasium as gym
-# except ImportError:
-#     print("gynasium is not installed, use gym instead")
-import gym
+try:
+    import gymnasium as gym
+except ImportError:
+    print("gynasium is not installed, use gym instead")
+    import gym
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
@@ -97,7 +97,7 @@ def from_space_to_spec(space_def: gym.Space, name: str) -> specs:
     if isinstance(space_def, gym.spaces.dict.Dict):
         spec = {
             key: specs.Array(
-                shape=space.shape,
+                shape=space_def.shape if space_def.shape is not None else (),
                 dtype=space.dtype,
                 name=key,
             )
@@ -105,7 +105,7 @@ def from_space_to_spec(space_def: gym.Space, name: str) -> specs:
         }
     else:
         spec = specs.Array(
-            shape=space_def.shape,
+            shape=space_def.shape if space_def.shape is not None else (),
             dtype=space_def.dtype,
             name=name,
         )

--- a/oxe_envlogger/data_type.py
+++ b/oxe_envlogger/data_type.py
@@ -98,7 +98,7 @@ def from_space_to_spec(space_def: gym.Space, name: str) -> specs:
         spec = {
             key: specs.Array(
                 shape=space_def.shape if space_def.shape is not None else (),
-                dtype=space.dtype,
+                dtype=space_def.dtype,
                 name=key,
             )
             for key, space in space_def.spaces.items()

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -8,6 +8,7 @@ from dm_env import specs
 
 from typing import Any, Dict, List, Tuple, Callable, Optional
 from oxe_envlogger.data_type import from_space_to_spec, enforce_type_consistency
+import copy
 
 
 class GymReturn:
@@ -31,6 +32,9 @@ class GymReturn:
             info = {}
         else:
             obs, reward, terminate, truncate, info = val
+        # NOTE: since logging is done async, this is important to ensure the obs is
+        # immutable even after wrapper, thus deepcopy
+        obs = copy.deepcopy(obs)
         return obs, reward, terminate, truncate, info
 
     def convert_reset(val: Any) -> Tuple[np.ndarray, dict]:
@@ -44,6 +48,9 @@ class GymReturn:
             info = {}
         else:
             obs, info = val
+        # NOTE: since logging is done async, this is important to ensure the obs is
+        # immutable even after wrapper, thus deepcopy
+        obs = copy.deepcopy(obs)
         return obs, info
 
 

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import gym
 import dm_env
-from dm_env import specs
+from dm_env import TimeStep, StepType, specs
 
 from typing import Any, Dict, List, Tuple, Callable, Optional
 from oxe_envlogger.data_type import from_space_to_spec, enforce_type_consistency
@@ -106,7 +106,10 @@ class DummyDmEnv():
         obs = enforce_type_consistency(self.observation_space, obs)
 
         if terminate:
-            ts = dm_env.termination(reward=reward, observation=obs)
+            # NOTE: explicitly set discount to custom float32 since dm_env.termination() is using float64
+            # https://github.com/google-deepmind/dm_env/blob/91b46797fea731f80eab8cd2c8352a0674141d89/dm_env/_environment.py#L226
+            # ts = dm_env.termination(reward=reward, observation=obs), 
+            ts = TimeStep(StepType.LAST, reward, np.float32(0.0), obs)
         elif truncate:
             ts = dm_env.truncation(reward=reward, observation=obs, discount=np.float32(1.0))
         else:

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -95,16 +95,16 @@ class DummyDmEnv():
             terminate = done
             truncate = False  # NOTE: truncate is not supported in gym<0.26.0
 
-        # ensure type consistency
-        reward = float(reward)
+        # ensure type consistency, with reward and discount below is float32 comply with spec
+        reward = np.float32(reward)
         obs = enforce_type_consistency(self.observation_space, obs)
 
         if terminate:
             ts = dm_env.termination(reward=reward, observation=obs)
         elif truncate:
-            ts = dm_env.truncation(reward=reward, observation=obs)
+            ts = dm_env.truncation(reward=reward, observation=obs, discount=np.float32(0.0))
         else:
-            ts = dm_env.transition(reward=reward, observation=obs)
+            ts = dm_env.transition(reward=reward, observation=obs, discount=np.float32(0.0))
         return ts
 
     def reset(self) -> dm_env.TimeStep:
@@ -134,14 +134,14 @@ class DummyDmEnv():
     def reward_spec(self):
         return specs.Array(
             shape=(),
-            dtype=np.float64,
+            dtype=np.float32,
             name='reward',
         )
 
     def discount_spec(self):
         return specs.Array(
             shape=(),
-            dtype=np.float64,
+            dtype=np.float32,
             name='discount',
         )
 

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -102,9 +102,9 @@ class DummyDmEnv():
         if terminate:
             ts = dm_env.termination(reward=reward, observation=obs)
         elif truncate:
-            ts = dm_env.truncation(reward=reward, observation=obs, discount=np.float32(0.0))
+            ts = dm_env.truncation(reward=reward, observation=obs, discount=np.float32(1.0))
         else:
-            ts = dm_env.transition(reward=reward, observation=obs, discount=np.float32(0.0))
+            ts = dm_env.transition(reward=reward, observation=obs, discount=np.float32(1.0))
         return ts
 
     def reset(self) -> dm_env.TimeStep:

--- a/oxe_envlogger/dm_env.py
+++ b/oxe_envlogger/dm_env.py
@@ -86,7 +86,6 @@ class DummyDmEnv():
         Standard dm_env.step interface
         Note: dm_env.step doesn't accept additional arguments
         """
-        action = enforce_type_consistency(self.action_space, action)
         if self.custom_step_env_callback:
             val = self.custom_step_env_callback(action)
         else:

--- a/oxe_envlogger/envlogger.py
+++ b/oxe_envlogger/envlogger.py
@@ -17,7 +17,7 @@ import tensorflow_datasets as tfds
 import tensorflow as tf
 
 from typing import Any, Dict, Tuple, Optional
-from oxe_envlogger.data_type import from_space_to_feature, populate_docs
+from oxe_envlogger.data_type import from_space_to_feature, populate_docs, enforce_type_consistency
 from oxe_envlogger.dm_env import GymReturn, DummyDmEnv
 from abc import ABC, abstractmethod
 
@@ -167,6 +167,7 @@ class OXEEnvLogger(gym.Wrapper, EnvLoggerBase):
     def step(self, action, **kwargs) -> Tuple:
         """Refer to abstract method in EnvLoggerBase"""
         self.dm_env_base.step_kwargs = kwargs  # experimental
+        action = enforce_type_consistency(self.dm_env.action_space, action)
         val = self.dm_env.step(action)
         self.dm_env_base.step_kwargs = {}
         return GymReturn.convert_step(val)

--- a/oxe_envlogger/envlogger.py
+++ b/oxe_envlogger/envlogger.py
@@ -5,11 +5,11 @@ import sys
 import os
 import numpy as np
 
-try:
-    import gymnasium as gym
-except ImportError:
-    print("gynasium is not installed, use gym instead")
-    import gym
+# try:
+#     import gymnasium as gym
+# except ImportError:
+#     print("gynasium is not installed, use gym instead")
+import gym
 
 import envlogger
 from envlogger.backends import tfds_backend_writer
@@ -137,8 +137,8 @@ class OXEEnvLogger(gym.Wrapper, EnvLoggerBase):
             observation_info=from_space_to_feature(
                 env.observation_space, doc_field),
             action_info=from_space_to_feature(env.action_space, doc_field),
-            reward_info=np.float64,
-            discount_info=np.float64,
+            reward_info=np.float32,
+            discount_info=np.float32,
             step_metadata_info=step_metadata_info,
             episode_metadata_info=episode_metadata_info,
             version=version,
@@ -282,8 +282,8 @@ class AutoOXEEnvLogger(gym.Wrapper, EnvLoggerBase):
             name=self.dataset_name,
             observation_info=observation_info,
             action_info=action_info,
-            reward_info=np.float64,
-            discount_info=np.float64,
+            reward_info=np.float32,
+            discount_info=np.float32,
             step_metadata_info=step_metadata_info,
             episode_metadata_info=episode_metadata_info,
             version=self.default_version,

--- a/oxe_envlogger/envlogger.py
+++ b/oxe_envlogger/envlogger.py
@@ -5,11 +5,11 @@ import sys
 import os
 import numpy as np
 
-# try:
-#     import gymnasium as gym
-# except ImportError:
-#     print("gynasium is not installed, use gym instead")
-import gym
+try:
+    import gymnasium as gym
+except ImportError:
+    print("gynasium is not installed, use gym instead")
+    import gym
 
 import envlogger
 from envlogger.backends import tfds_backend_writer

--- a/oxe_envlogger/envlogger.py
+++ b/oxe_envlogger/envlogger.py
@@ -156,8 +156,8 @@ class OXEEnvLogger(gym.Wrapper, EnvLoggerBase):
             store_ds_metadata=True,
         )
 
-        dm_env = DummyDmEnv(env)
-        self.dm_env = envlogger.EnvLogger(dm_env,
+        self.dm_env_base = DummyDmEnv(env)
+        self.dm_env = envlogger.EnvLogger(self.dm_env_base,
                                           step_fn=step_metadata_fn,
                                           episode_fn=episode_metadata_fn,
                                           backend=writer
@@ -166,16 +166,16 @@ class OXEEnvLogger(gym.Wrapper, EnvLoggerBase):
 
     def step(self, action, **kwargs) -> Tuple:
         """Refer to abstract method in EnvLoggerBase"""
-        self.dm_env.step_kwargs = kwargs  # experimental
+        self.dm_env_base.step_kwargs = kwargs  # experimental
         val = self.dm_env.step(action)
-        self.dm_env.step_kwargs = {}
+        self.dm_env_base.step_kwargs = {}
         return GymReturn.convert_step(val)
 
     def reset(self, **kwargs) -> Tuple:
         """Refer to abstract method in EnvLoggerBase"""
-        self.dm_env.reset_kwargs = kwargs  # experimental
+        self.dm_env_base.reset_kwargs = kwargs  # experimental
         val = self.dm_env.reset()
-        self.dm_env.reset_kwargs = {}
+        self.dm_env_base.reset_kwargs = {}
         return GymReturn.convert_reset(val)
 
     def set_step_metadata(self, metadata: Dict[str, Any]):

--- a/reshard_rlds.py
+++ b/reshard_rlds.py
@@ -3,8 +3,8 @@
 import os
 import argparse
 import copy
-from oxe_envlogger.utils import \
-    find_datasets, get_datasets, merge_datasets, save_rlds_dataset
+from oxe_envlogger.utils import find_datasets, save_rlds_dataset
+import tensorflow_datasets as tfds
 
 
 def print_yellow(x): return print("\033[93m {}\033[00m" .format(x))
@@ -22,16 +22,16 @@ if __name__ == "__main__":
     dataset_dirs = find_datasets(args.rlds_dirs)
     print_yellow(f"Found {dataset_dirs} rlds datasets to merge.")
 
-    # Load datasets from given directories
-    datasets, dataset_infos = get_datasets(dataset_dirs)
-    
-    # Merged datasets and get the size info of the merged dataset
-    merged_dataset = merge_datasets(datasets)
-    total_size = sum([info.dataset_size for info in dataset_infos])
+    # Create a merged dataset of all the datasets in the given directories
+    builder = tfds.builder_from_directories(list(dataset_dirs))
+    merged_dataset = builder.as_dataset(split='all')
+
+    dataset_info = builder.info
+    total_size = dataset_info.dataset_size
     recommended_shard_size = round(200*1024*1024*len(merged_dataset)/total_size)
 
     print_yellow(f"Total size of datasets: {total_size/1024.0} kb")
-    print_yellow(f"Merging {len(datasets)} datasets with "
+    print_yellow(f"Merging {len(dataset_dirs)} datasets with "
                  f"total {len(merged_dataset)} episodes.")
     print_yellow(f"!!NOTE!! It is recommended to keep tfrecord size at "
                  f"around 200MB. Thus the recommended shard size should "
@@ -40,14 +40,14 @@ if __name__ == "__main__":
     def update_data_dir(target_dir, dataset_info):
         # Bug in update_data_dir() method, need to update the identity object as well
         # https://github.com/tensorflow/datasets/pull/5297
-        dataset_info.update_data_dir(target_dir)
+        # dataset_info.update_data_dir(target_dir) # not supported in MultiSplitInfo()
         dataset_info._identity.data_dir = target_dir
 
     # Create a new dataset info with the updated data_dir
-    dataset_info = copy.deepcopy(dataset_infos[0])
+    dataset_info = copy.deepcopy(dataset_info)
     update_data_dir(args.output_rlds, dataset_info)
     assert dataset_info.data_dir == args.output_rlds
-    print(dataset_info)
+    # print(dataset_info)
 
     if not os.path.exists(args.output_rlds):
         os.makedirs(args.output_rlds)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='oxe_envlogger',
-    version='0.0.1',
+    version='0.0.2,
     description='library to log env to tfds',
     url='https://github.com/rail-berkeley/oxe_envlogger',
     author='auth',

--- a/tests/log_rlds.py
+++ b/tests/log_rlds.py
@@ -20,16 +20,17 @@ def main(_):
         dataset_name="test_rlds",
         directory="logs",
         max_episodes_per_file=1,
+        step_metadata_info={"lang_text": tfds.features.Text()},
     )
 
     # 2. Log data
     for i in range(3):
         for j in range(10):
             if j == 0: # need to log every first step in traj as a restart
-                step_type = RLDSStepType.RESTART
+                _mdata = {"lang_text": f"hello {i}"}
+                logger(action_sample, obs_sample, 1.0, metadata=_mdata, step_type=RLDSStepType.RESTART)
             else:
-                step_type = RLDSStepType.TRANSITION
-            logger(action_sample, obs_sample, 1.0, step_type=step_type)
+                logger(action_sample, obs_sample, 1.0, step_type=RLDSStepType.TRANSITION)
         logger(action_sample, obs_sample, 1.0, step_type=RLDSStepType.TERMINATION)
 
     logger.close()


### PR DESCRIPTION
 - fix discount reward default float32 and support tensor.image type
 - use default float32 for all tensors instead of float64
 - logging bug when nested wrap with logger when obs and action is changed, due to async nature of loggin, use deepcopy()
 - support custom step metadata in rldslogger